### PR TITLE
TL-549 never fall back to sync behaviour

### DIFF
--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -127,13 +127,8 @@ module Airbrake
     end
 
     def default_sender
-      return @async_sender if @async_sender.has_workers?
-
-      @config.logger.warn(
-        "#{LOG_LABEL} falling back to sync delivery because there are no " \
-        "running async workers"
-      )
-      @sync_sender
+      # Always send asynchronously to avoid blocking
+      return @async_sender
     end
 
     def clean_backtrace


### PR DESCRIPTION
Avoids falling back to synchronous behaviour when the asynchronous notifier has no workers left.

The errors will be only locally logged but we won't block the application if the synchronous notifier gets stuck

This will be used by RightScale until the official airbrake/airbrake-ruby gem has a similar behaviour
