### PR TITLE
Call has_workers? to spawn initial workers

### DIFF
--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -127,6 +127,8 @@ module Airbrake
     end
 
     def default_sender
+      # This spawns workers if necessary
+      @async_sender.has_workers?
       # Always send asynchronously to avoid blocking
       return @async_sender
     end


### PR DESCRIPTION
It is necessary to call async_sender.has_workers? to spawn the initial set of workers, see https://github.com/rightscale/airbrake-ruby/blob/master/lib/airbrake-ruby/async_sender.rb#L78-L87
